### PR TITLE
Fixed je_dual_monarchy, so that it actually works (now for real)

### DIFF
--- a/better-politics-mod/common/journal_entries/zz_bpm_00_dual_monarchy.txt
+++ b/better-politics-mod/common/journal_entries/zz_bpm_00_dual_monarchy.txt
@@ -17,6 +17,14 @@
 			has_law = law_type:law_national_supremacy
 			has_law = law_type:law_ethnostate
 		}
+		OR = {
+			NOT = {
+				has_variable = bpm_hungarian_revolution_started # can only form Austria-Hungary after putting down the revolution
+			}
+			c:HUN = {
+				is_direct_subject_of = c:AUS # or franticly negotiated for a personal union (or has Hungary as subject for any other reason)
+			}
+		}
 	}
 
 	on_complete = {
@@ -26,10 +34,15 @@
 	}
 
 	fail = {
-		cu:hungarian = {
-			culture_secession_progress = {
-				target = ROOT
-				value > 0.5
+		OR = {
+			cu:hungarian = {
+				culture_secession_progress = {
+					target = ROOT
+					value > 0.5
+				}
+			}
+			c:HUN = {
+				liberty_desire >= 75
 			}
 		}
 	}
@@ -56,6 +69,14 @@
 			NOT = {
 				this = c:AUS
 			}
+		}
+		NOT = {
+			c:HUN = {
+				is_direct_subject_of = c:AUS
+			}
+		}
+		NOT = {
+			has_variable = bpm_hungarian_revolution_started # keep the journal entry active durring the revolution, so the historical path can be achieved
 		}
 	}
 

--- a/better-politics-mod/events/_dual_monarchy.txt
+++ b/better-politics-mod/events/_dual_monarchy.txt
@@ -51,13 +51,19 @@ dual_monarchy.1 = {
 		default_option = yes
 		custom_tooltip = austria_hungary_tt
 		add_primary_culture = cu:hungarian
+		if = {
+			limit = {
+				exists = c:HUN
+			}
+			annex = c:HUN
+		}
 		add_loyalists = {
 			culture = cu:hungarian
 			value = 0.2
 		}
 		every_interest_group = {
 			limit = {
-				has_ideology = ideology:ideology_cit_nationalism
+				has_ideology = ideology:ideology_cit_nationalist
 			}
 			bpm_remove_all_cit_ideologies = yes
 			add_ideology = ideology_cit_multiethnic_nationalist
@@ -76,9 +82,15 @@ dual_monarchy.1 = {
 		}
 		custom_tooltip = austria_hungary_tt
 		add_primary_culture = cu:hungarian
+		if = {
+			limit = {
+				exists = c:HUN
+			}
+			annex = c:HUN
+		}
 		every_interest_group = {
 			limit = {
-				has_ideology = ideology:ideology_cit_nationalism
+				has_ideology = ideology:ideology_cit_nationalist
 			}
 			bpm_remove_all_cit_ideologies = yes
 			add_ideology = ideology_cit_multiethnic_nationalist
@@ -105,20 +117,28 @@ dual_monarchy.1 = {
 		trigger = {
 			has_variable = dual_monarchy_fail
 		}
-		add_radicals = {
-			value = very_large_radicals
-			culture = cu:hungarian
-		}
-		# add radicals from discrimination
-		every_scope_state = {
+		if = {
 			limit = {
-				state_region = {
-					is_homeland = cu:hungarian
-				}
+				exists = c:HUN
 			}
-			add_modifier = {
-				name = dual_monarchy_compromise_rejected
-				months = long_modifier_time
+			set_relations = { country = c:HUN value = -35 }
+		}
+		else = {
+			add_radicals = {
+				value = very_large_radicals
+				culture = cu:hungarian
+			}
+			# add radicals from discrimination
+			every_scope_state = {
+				limit = {
+					state_region = {
+						is_homeland = cu:hungarian
+					}
+				}
+				add_modifier = {
+					name = dual_monarchy_compromise_rejected
+					months = long_modifier_time
+				}
 			}
 		}
 	}

--- a/better-politics-mod/events/_peoples_springtime.txt
+++ b/better-politics-mod/events/_peoples_springtime.txt
@@ -969,9 +969,56 @@ peoples_springtime.13 = {
 
 	icon = "gfx/interface/icons/event_icons/event_protest.dds"
 
-	title = peoples_springtime.13.t
-	desc = peoples_springtime.13.d
-	flavor = peoples_springtime.13.f
+	title = {
+		first_valid = {
+			triggered_desc = {
+				desc = peoples_springtime.13.t
+				trigger = {
+					NOT = { owns_entire_state_region = STATE_CENTRAL_HUNGARY }
+				}
+			}
+			triggered_desc = {
+				desc = peoples_springtime.13.t2
+				trigger = {
+					owns_entire_state_region = STATE_CENTRAL_HUNGARY
+				}
+			}
+		}
+	}
+	
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				desc = peoples_springtime.13.d
+				trigger = {
+					NOT = { owns_entire_state_region = STATE_CENTRAL_HUNGARY }
+				}
+			}
+			triggered_desc = {
+				desc = peoples_springtime.13.d2
+				trigger = {
+					owns_entire_state_region = STATE_CENTRAL_HUNGARY
+				}
+			}
+		}
+	}
+
+	flavor = {
+		first_valid = {
+			triggered_desc = {
+				desc = peoples_springtime.13.f
+				trigger = {
+					NOT = { owns_entire_state_region = STATE_CENTRAL_HUNGARY }
+				}
+			}
+			triggered_desc = {
+				desc = peoples_springtime.13.f2
+				trigger = {
+					owns_entire_state_region = STATE_CENTRAL_HUNGARY
+				}
+			}
+		}
+	}
 
 	duration = 1
 
@@ -980,7 +1027,6 @@ peoples_springtime.13 = {
 	trigger = {
 		has_variable = bpm_hungarian_revolution_started
 		NOT = { has_variable = bpm_austria_empire_dissolved }
-		NOT = { owns_entire_state_region = STATE_CENTRAL_HUNGARY }
 		owner = {
 			is_at_war = no
 			is_diplomatic_play_initiator = no
@@ -988,31 +1034,43 @@ peoples_springtime.13 = {
 	}
 
 	immediate = {
-		create_country = {
-			tag = GAL
-			origin = c:AUS
-			state = s:STATE_EAST_GALICIA.region_state:AUS
-		}
-		s:STATE_WEST_GALICIA.region_state:AUS = { set_state_owner = c:GAL set_state_type = incorporated}
-		s:STATE_MOLDAVIA.region_state:AUS = { set_state_owner = c:GAL set_state_type = incorporated}
-		set_variable = bpm_austria_empire_dissolved
 		remove_variable = bpm_hungarian_revolution_started
+		if = {
+			limit = {
+				NOT = { owns_entire_state_region = STATE_CENTRAL_HUNGARY }
+			}
+			create_country = {
+				tag = GAL
+				origin = c:AUS
+				state = s:STATE_EAST_GALICIA.region_state:AUS
+			}
+			s:STATE_WEST_GALICIA.region_state:AUS = { set_state_owner = c:GAL set_state_type = incorporated}
+			s:STATE_MOLDAVIA.region_state:AUS = { set_state_owner = c:GAL set_state_type = incorporated}
+			set_variable = bpm_austria_empire_dissolved
+			hidden_effect = {
+				create_diplomatic_pact = {
+					country = c:GAL
+					type = personal_union
+				}
+			}
+		}
 	}
 
 	option = {
+		trigger = {
+			NOT = { owns_entire_state_region = STATE_CENTRAL_HUNGARY }
+		}
 		name = peoples_springtime.13.a #release galicia
 
 		custom_tooltip = {
 			text = bpm_gl_union
 		}
-		
-		
-		hidden_effect = {
-			create_diplomatic_pact = {
-				country = c:GAL
-				type = personal_union
-			}
+	}
+	option = {
+		trigger = {
+			owns_entire_state_region = STATE_CENTRAL_HUNGARY
 		}
+		name = peoples_springtime.13.b #the hungarian revolution is defeated
 	}
 }
 

--- a/better-politics-mod/localization/english/BPM_springtime_l_english.yml
+++ b/better-politics-mod/localization/english/BPM_springtime_l_english.yml
@@ -3,7 +3,7 @@
  1848.13.t:0 "The Hungry Forties"
  1848.13.d:0 "Beginning in the mid-1840s, blight and poor harvests cratered crop yields across Western Europe. The resulting famines would cause a chain reaction of economic crises, throwing the nascent industrial order into disarray and triggering political discontent in all sectors of society."
  1848.13.f:0 "The bourgeoisie, which had scarcely recovered from the depressing discovery that one of the basic pillars of its whole social order, the potato, was in danger, now sees its second pillar, cotton, threatened as well. If but a single moderately poor cotton harvest and the prospect of a second one could provoke grave alarm amid the jubilation of prosperity, a few years in succession of outright failure in cotton will inevitably hurl the whole of civilized society temporarily back into barbarism.\n\n—Karl Marx, 1850"
- 1848.13.a:0 "A storm is coming.
+ 1848.13.a:0 "A storm is coming."
 
  peoples_springtime.100.t:0 "Bowing to the Masses"
  peoples_springtime.100.d:0 "The days of petitions and debate clubs are over. Early this morning, a crowd of protestors breached the outer walls of [GetPlayer.GetRuler.GetFullNameWithTitle]'s residence, chanting 'Freedom or Death' and demanding a whole new constitution. Luckily, our loyal guards repelled the crowd before they could go much further, but it seems that this has only enraged them further. The masses are willing to risk their lives. Are we?"
@@ -56,9 +56,13 @@
  peoples_springtime.12.b:0 "Long live the Republic!"
 
  peoples_springtime.13.t:0 "Picking Up the Pieces"
+ peoples_springtime.13.t2:0 "Putting the Pieces Back Together"
  peoples_springtime.13.d:0 "With the lands of Saint Stephen dragged from our grasp we must now reorganize our territories, lest we spiral into collapse. The Kingdom of Galicia and Lodomeria is another crownland aquired from the defunct Polish-Lithuanian Commonwealth, and is now only tied to us by narrow corridor and the wavering loyalties of millions of Poles and Ruthenians. Granting the kingdom autonomy is the only way to ensure they remain tied to us."
+ peoples_springtime.13.d2:0 "TODO:\ Write victory speech"
  peoples_springtime.13.f:0 "A union half a millenia old, lost to the dustbin of history."
+ peoples_springtime.13.f2:0 "TODO"
  peoples_springtime.13.a:0 "An empire of dirt."
+ peoples_springtime.13.b:0 "The Hungarian Revolution is defeated."
  bpm_gl_union:0 "Releases #gold Galicia-Lodomeria#! in a personal union."
 
  peoples_springtime.14.t:0 "Papal Authority Toppled in Rome"


### PR DESCRIPTION
The dual monarchy je was completely useless, because whit the Hungarian Revolution event chain Hungary became independent, which in turn made the journal entry instantly invalid. Whit the changes I made, the journal entry now can only become invalid, if:

- Austria forms another tag or doesn't control any Hungarian homelands (previous behavior)
- Hungary isn't a subject of Austria
- the Hungarian Revolution is not in progress

Additionally, Austria-Hungary can be formed if Hungary is an Austrian subject.

I needed to modify peoples_springtime.13 (Galicia personal union event), so I can track when the Hungarian Revolution is over, since it already fired when it was successful. Added another option to it, which just informs the player that the revolution has been dealt with. I couldn't come up with a description and flavor text for it, so someone who can write better localization than me is free to make it.

Also there were three typos I corrected:

- "ideology:ideology_cit_nationalist" was misspelled as "ideology:ideology_cit_nationalism" in two places
- there was a missing double quote at the beginning of the peoples springtime loc file

(Sorry about the previous pull request, I'm not that great at git and GitHub yet)