### PR TITLE
Various bug fixed

### DIFF
--- a/better-politics-mod/common/character_templates/zz_bpm_country_clm.txt
+++ b/better-politics-mod/common/character_templates/zz_bpm_country_clm.txt
@@ -25,7 +25,7 @@ CLM_Jose_Marquez = {
 	historical = yes
 	ig_leader = yes
 	birth_date = 1793.9.9
-	interest_group = ig_liberals #ig_petty_bourgeoisie
+	interest_group = ig_radicals #ig_petty_bourgeoisie #used to be ig_liberals but that caused issues with the President being from the same group
 	ideology = ideology_radical
 	traits = {
 		direct

--- a/better-politics-mod/common/history/characters/cub - cuba.txt
+++ b/better-politics-mod/common/history/characters/cub - cuba.txt
@@ -1,0 +1,20 @@
+﻿CHARACTERS = {
+	c:CUB ?= {
+		create_character = {
+			# Miguel Tacon y Rosique
+			first_name = "Miguel"
+			last_name = "Taco_n_y_Rosique"
+			historical = yes
+			culture = primary_culture
+			ruler = yes
+			age = 61
+			dna = dna_miguel_tacon_y_rosique
+			ig_leader = yes
+			interest_group = ig_armed_forces
+			ideology = ideology_moderate
+			traits = {
+				cruel
+			}
+		}	
+	}
+}

--- a/better-politics-mod/common/history/characters/dei - dutch east indies.txt
+++ b/better-politics-mod/common/history/characters/dei - dutch east indies.txt
@@ -1,0 +1,21 @@
+﻿CHARACTERS = {
+	c:DEI ?= {
+		create_character = {
+			first_name = "Jean_Chretien"
+			last_name = "Baud"
+			historical = yes
+			ruler = yes
+			culture = cu:dutch
+			age = 47
+			ig_leader = yes
+			interest_group = ig_landowners
+			ideology = ideology_moderate
+			traits = {
+				arrogant
+			}
+		}
+		create_character = {
+			template = DEI_Frans_David_Cochius
+		}
+	}
+}

--- a/better-politics-mod/common/history/characters/phi - philippines.txt
+++ b/better-politics-mod/common/history/characters/phi - philippines.txt
@@ -1,0 +1,19 @@
+﻿CHARACTERS = {
+	c:PHI ?= {
+		create_character = {
+			# Pedro Antonio Salazar Castillo y Varona, governor-general of the Philippines from 1835 to 1837
+			first_name = "Pedro_Antonio"
+			last_name = "Salazar_Castillo"
+			historical = yes
+			ruler = yes
+			birth_date = 1782.02.19
+			culture = cu:spanish
+			ig_leader = yes
+			interest_group = ig_landowners
+			ideology = ideology_moderate
+			traits = {
+				cautious
+			}
+		}
+	}
+}

--- a/better-politics-mod/common/ideologies/bpm_leader_ideologies.txt
+++ b/better-politics-mod/common/ideologies/bpm_leader_ideologies.txt
@@ -1682,11 +1682,9 @@ ideology_jingoist_leader = {
 		# less likely if left-wing
 		if = {
 			limit = {
-				interest_group = {
-					OR = {
-						bpm_ig_is_left_wing = yes
-						bpm_ig_is_lower_institutional = yes
-					}
+				OR = {
+					bpm_ig_is_left_wing = yes
+					bpm_ig_is_lower_institutional = yes
 				}
 			}
 			add = -100
@@ -1802,9 +1800,7 @@ ideology_royalist = {
 				owner = {
 					has_law = law_type:law_monarchy
 				}
-				interest_group = {
-					ig_approval > 5
-				}
+				ig_approval > 5
 			}
 			add = 50
 		}
@@ -1814,20 +1810,16 @@ ideology_royalist = {
 				owner = {
 					has_law = law_type:law_monarchy
 				}
-				interest_group = {
-					ig_approval < 0
-				}
+				ig_approval < 0
 			}
 			add = -50
 		}
 		# less likely if liberal
 		if = {
 			limit = {
-				interest_group = {
-					OR = {
-						bpm_ig_is_liberal = yes
-						bpm_ig_is_proletarian = yes
-					}
+				OR = {
+					bpm_ig_is_liberal = yes
+					bpm_ig_is_proletarian = yes
 				}
 			}
 			add = -75

--- a/better-politics-mod/common/parties/zzzz_conservative_party.txt
+++ b/better-politics-mod/common/parties/zzzz_conservative_party.txt
@@ -123,6 +123,7 @@ conservative_party = {
 				desc = party_conservative_ast
 				trigger = {
 					country_has_primary_culture = cu:australian
+					exists = c:NZL
 					NOT = {THIS = c:NZL}
 				}
 			}

--- a/better-politics-mod/common/parties/zzzz_liberal_party.txt
+++ b/better-politics-mod/common/parties/zzzz_liberal_party.txt
@@ -134,6 +134,7 @@ liberal_party = {
 				desc = party_liberal_ast
 				trigger = {
 					country_has_primary_culture = cu:australian
+					exists = c:NZL
 					NOT = {THIS = c:NZL}
 				}
 			}


### PR DESCRIPTION
* fixed a few errors related to bpm_leader_ideologies.txt
* fixed a pair of bugs related to zzzz_liberal_party.txt and zzzz_conservative_party.txt which resulted in 400 errors
* all rulers that were not assigned to be the leader of an IG despite their country's laws making that illegal have been made leader of their respective IG.
  - Pedro Antonio Salazar Castillo (Philippines) has become leader of landowners.
  - Miguel Tacón y Rosique (Cuba) has become leader of landowners.
  - Francisco de Paula Santander (New Grenada) has become leader of liberals. The current leader of the liberals (historical character with Radical ideology) has become the leader of the radicals instead.
  - Jean Chrétien Baud (Dutch East Indies) has become leader of landowners.