### PR TITLE
Fix for colonial slavery and aristocrats and reactionaries attraction tweaks

### DIFF
--- a/better-politics-mod/common/interest_groups/zzzz_landowners.txt
+++ b/better-politics-mod/common/interest_groups/zzzz_landowners.txt
@@ -242,11 +242,32 @@ REPLACE:ig_landowners = {
 			desc = "SLAVERY_DETRACTORS"
 			if = {
 				limit = {
-					owner = { NOT = { has_law = law_type:law_slavery_banned } }
+					owner = {
+							NAND = {
+								has_law_or_variant = law_slavery_banned
+								has_law_or_variant = law_colonial_slavery
+							} 
+					}
+					NOT = { is_pop_type = aristocrats }
 					OR = {
-						pop_has_primary_culture = no
+						#pop_has_primary_culture = no
+						pop_acceptance <= acceptance_status_3
 						state = { is_slave_state = no }
 					}
+				}
+				value = -300
+			}
+			else_if = {
+				limit = {
+					owner = {
+						has_law = law_type:law_colonial_slavery
+					}
+					OR = {
+						#pop_has_primary_culture = no
+						pop_acceptance <= acceptance_status_3
+						state = { is_incorporated = no }
+					}
+					NOT = { is_pop_type = aristocrats }
 				}
 				value = -300
 			}
@@ -267,6 +288,13 @@ REPLACE:ig_landowners = {
 				add = {
 					desc = "SLAVEHOLDERS"
 					value = 400
+				}
+			}
+			else_if = {
+				limit = { state = { is_incorporated = yes } owner = { has_law_or_variant= law_type:law_colonial_slavery } }
+				add = {
+					desc = "SLAVEHOLDERS"
+					value = 200
 				}
 			}
 		}

--- a/better-politics-mod/common/interest_groups/zzzzz_BPM_reactionaries.txt
+++ b/better-politics-mod/common/interest_groups/zzzzz_BPM_reactionaries.txt
@@ -272,17 +272,55 @@
 					}
 					value = 200
 				}
+				else_if = {
+					limit = {
+						owner = { has_law = law_type:law_colonial_slavery }
+						state = { is_incorporated = yes }
+						is_pop_type = aristocrats
+					}
+					value = 150
+				}
+				else_if = {
+					limit = {
+						owner = { has_law = law_type:law_colonial_slavery }
+						state = { is_incorporated = yes }
+						OR = {
+							is_pop_type = officers
+							is_pop_type = clergymen
+						}
+					}
+					value = 50
+				}
 			}
-	
+
 			add = {
 				desc = "SLAVERY_DETRACTORS"
 				if = {
 					limit = {
-						owner = { NOT = { has_law = law_type:law_slavery_banned } }
+						owner = {
+							NAND = {
+								has_law_or_variant = law_slavery_banned
+								has_law_or_variant = law_colonial_slavery
+							}
+						}
+						NOT = { is_pop_type = aristocrats }
 						OR = {
-							pop_has_primary_culture = no
+							#pop_has_primary_culture = no
+							pop_acceptance <= acceptance_status_3
 							state = { is_slave_state = no }
 						}
+					}
+					value = -150
+				}
+				else_if = {
+					limit = {
+						owner = { has_law = law_type:law_colonial_slavery }
+						OR = {
+							#pop_has_primary_culture = no
+							pop_acceptance <= acceptance_status_3
+							state = { is_incorporated = no }
+						}
+						NOT = { is_pop_type = aristocrats }
 					}
 					value = -150
 				}


### PR DESCRIPTION
Currently under colonial slavery pops in incorporated states cant join aristocratic interest or reactionaries, this edit fixes it and reworks attraction logic regarding slavery for those igs.
1) Under any slavery law other than colonial slavery or slavery banned, non aristocrat pops with acceptance level of open prejudice or lower (instead of non primary culture) and pops in free states won't join those igs.
2) Under colonial slavery non aristocrat pops with acceptance level of open prejudice or lower and pops in non incorporated states won't join those igs, and aristocrats in incorporated states have increased weight toward those igs.