### PR TITLE
Fix Invite Investment button never being available for Russia

### DIFF
--- a/better-politics-mod/common/scripted_buttons/bpm_modernizer_buttons.txt
+++ b/better-politics-mod/common/scripted_buttons/bpm_modernizer_buttons.txt
@@ -359,21 +359,23 @@ bpm_je_modernizers_invite_production_button = {
 			}
 		}
 		has_technology_researched = railways
-		country_has_building_type_levels = {
-			target = bt:building_railway
-			value = 0
-		}
-		country_has_building_type_levels = {
-			target = bt:building_motor_industry
-			value = 0
-		}
-		country_has_building_type_levels = {
-			target = bt:building_steel_mill
-			value = 0
-		}
-		country_has_building_type_levels = {
-			target = bt:building_tooling_workshop
-			value = 0
+		NAND = { # Usable while at least one of these is missing; the effect only creates the ones you lack
+			country_has_building_type_levels = {
+				target = bt:building_railway
+				value >= 1
+			}
+			country_has_building_type_levels = {
+				target = bt:building_motor_industry
+				value >= 1
+			}
+			country_has_building_type_levels = {
+				target = bt:building_steel_mill
+				value >= 1
+			}
+			country_has_building_type_levels = {
+				target = bt:building_tooling_workshop
+				value >= 1
+			}
 		}
 		any_country = {
 			country_rank = rank_value:great_power


### PR DESCRIPTION
## Problem

The **Invite Investment** button on `je_bpm_modernizers` requires the country to have **exactly 0 levels of all four building types at once** (railway, motor industry, steel mill, tooling workshop):

```
country_has_building_type_levels = {
    target = bt:building_tooling_workshop
    value = 0    # equality check
}
```

Vanilla 1836 **Russia starts with tooling workshops** in four of its states (`history/buildings/15_russia.txt`), so the flagship country of this journal entry can never press the button in an unmodded campaign. The same applies to any unrecognized country that has built (or been handed) a single level of any of the four buildings.

This looks unintended, because the button's own `effect` guards each `create_building` with a per-building "has 0 of this type" check — i.e. it was written to gracefully skip buildings you already have and only create the missing ones. With the current `possible` block those guards are dead code.

## Fix

Replace the four AND-ed equality checks with a `NAND` over `value >= 1` checks, mirroring the pattern already used by the other three modernizer buttons (NAND over their tech lists): the button stays available while **at least one** of the four buildings is missing, and the effect creates only the missing ones.

## Notes (not addressed here)

- The `OR` inside `any_country` (and the matching `random_country` limit in the effect) contains two identical `any_scope_treaty` branches checking `foreign_investment_rights` — presumably a leftover from the pact->treaty migration where the second branch used to check `foreign_investment_agreement`.
- The effect preview tooltip shows the created buildings with 0 levels because `scope:investor_country` is only saved when the effect actually runs; actual execution creates 1 level of each missing building correctly.

Same bug exists on `3.0-dev` (identical file), happy to retarget or duplicate the PR if you prefer it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)